### PR TITLE
Feature/brackets highlighter

### DIFF
--- a/TypeSqf/Highlighting/BracketsHighlighter.cs
+++ b/TypeSqf/Highlighting/BracketsHighlighter.cs
@@ -131,7 +131,8 @@ namespace TypeSqf.Edit.Highlighting
         }
 
         /// <summary>
-        ///  Find current matching brackets.
+        ///  Find current matching brackets. 
+        ///  Return null if offset is in comments, strings, pre processor commands
         /// </summary>
         /// <param name="offset">An offset inside brackets to be found.</param>
         /// <param name="openingBracket"></param>
@@ -153,10 +154,6 @@ namespace TypeSqf.Edit.Highlighting
                 {
                     case '#':
                         skipTo = _textEditor.Text.IndexOf('\n', i);
-                        if (skipTo > i)
-                        {
-                            i = skipTo;
-                        }
                         break;
                     case '/':
                         if (i < (_textEditor.Text.Length - 1))
@@ -165,18 +162,10 @@ namespace TypeSqf.Edit.Highlighting
                             if (nextChar == '/')
                             {
                                 skipTo = _textEditor.Text.IndexOf('\n', i);
-                                if (skipTo > i)
-                                {
-                                    i = skipTo;
-                                }
                             }
                             if (nextChar == '*')
                             {
                                 skipTo = _textEditor.Text.IndexOf("*/", i);
-                                if (skipTo > i)
-                                {
-                                    i = skipTo;
-                                }
                             }
                         }
                         break;
@@ -186,7 +175,6 @@ namespace TypeSqf.Edit.Highlighting
                             prevChar = _textEditor.Text[i - 1];
                             if (prevChar != '\\')
                             {
-                                i = skipTo;
                                 break;
                             }
                         }
@@ -197,14 +185,24 @@ namespace TypeSqf.Edit.Highlighting
                             prevChar = _textEditor.Text[i - 1];
                             if (prevChar != '\\')
                             {
-                                i = skipTo;
                                 break;
                             }
                         }
                         break;
                 }
 
-                if (skipTo == -1 && currentChar == openingBracket)
+                // Return null if text cursor was in something that was skipped.
+                if (offset > i && offset <= skipTo)
+                {
+                    return null;
+                }
+                if (skipTo > i)
+                {
+                    i = skipTo + 1;
+                    continue;
+                }
+
+                if (currentChar == openingBracket)
                 {
                     brackets.Push(i);
                     if (i >= offset)
@@ -212,7 +210,7 @@ namespace TypeSqf.Edit.Highlighting
                         bracketBalance++;
                     }
                 }
-                else if (skipTo == -1 && currentChar == closingBracket)
+                else if (currentChar == closingBracket)
                 {
                     if (brackets.Count > 0)
                     {

--- a/TypeSqf/Highlighting/BracketsHighlighter.cs
+++ b/TypeSqf/Highlighting/BracketsHighlighter.cs
@@ -1,5 +1,4 @@
 ﻿using ICSharpCode.AvalonEdit.Document;
-using ICSharpCode.AvalonEdit.Rendering;
 using System;
 using System.Collections.Generic;
 using System.Windows.Media;
@@ -9,8 +8,6 @@ using System.Threading.Tasks;
 using ICSharpCode.AvalonEdit;
 using ICSharpCode.AvalonEdit.Editing;
 using TypeSqf.Edit.Replace;
-using TypeSqf.Analyzer;
-using TypeSqf.Analyzer.Commands;
 
 namespace TypeSqf.Edit.Highlighting
 {

--- a/TypeSqf/Highlighting/BracketsHighlighter.cs
+++ b/TypeSqf/Highlighting/BracketsHighlighter.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 using ICSharpCode.AvalonEdit;
 using ICSharpCode.AvalonEdit.Editing;
 using TypeSqf.Edit.Replace;
+using TypeSqf.Analyzer;
+using TypeSqf.Analyzer.Commands;
 
 namespace TypeSqf.Edit.Highlighting
 {
@@ -53,42 +55,42 @@ namespace TypeSqf.Edit.Highlighting
             {
 
             }
-                
+            
             if (_bracketsEnding.Contains(textBefore))
             {
-                SearchResult result = new SearchResult(caretOffset - 1, 1);
-                _backgroundMarker.CurrentResults.Add(result);
-
                 char searchFor = _bracketsStarting[Array.IndexOf(_bracketsEnding, textBefore)];
                 CommentInfo comment = IsInComment(_textEditor.Text, caretOffset - 1);
-                
-                // loop document to begining
-                for (int i = caretOffset-2; i >= comment.StartOffset; i--)
+
+                if (!comment.InComment)
                 {
-                    if (MatchBrackets(i, searchFor, textBefore, comment.InComment))
+                    BracketsMatch bracketsMatch = FindMatchingBrackets(caretOffset - 1, searchFor, textBefore);
+
+                    if (bracketsMatch != null)
                     {
-                        SearchResult result1 = new SearchResult(i, 1);
+                        SearchResult result = new SearchResult(bracketsMatch.OpeningOffset, 1);
+                        _backgroundMarker.CurrentResults.Add(result);
+                        SearchResult result1 = new SearchResult(bracketsMatch.ClosingOffset, 1);
                         _backgroundMarker.CurrentResults.Add(result1);
-                        break;
                     }
                 }
+
+                
             }
             else if (_bracketsStarting.Contains(textAfter))
             {
-                SearchResult result = new SearchResult(caretOffset, 1);
-                _backgroundMarker.CurrentResults.Add(result);
-
                 char searchFor = _bracketsEnding[Array.IndexOf(_bracketsStarting, textAfter)];
                 CommentInfo comment = IsInComment(_textEditor.Text, caretOffset);
 
-                // loop document to begining
-                for (int i = caretOffset+1; i <= comment.EndOffset; i++)
+                if (!comment.InComment)
                 {
-                    if (MatchBrackets(i, searchFor, textAfter, comment.InComment))
+                    BracketsMatch bracketsMatch = FindMatchingBrackets(caretOffset + 1, textAfter, searchFor);
+
+                    if (bracketsMatch != null)
                     {
-                        SearchResult result1 = new SearchResult(i, 1);
+                        SearchResult result = new SearchResult(bracketsMatch.OpeningOffset, 1);
+                        _backgroundMarker.CurrentResults.Add(result);
+                        SearchResult result1 = new SearchResult(bracketsMatch.ClosingOffset, 1);
                         _backgroundMarker.CurrentResults.Add(result1);
-                        break;
                     }
                 }
             }
@@ -131,48 +133,112 @@ namespace TypeSqf.Edit.Highlighting
             return new CommentInfo(false, 0, text.Length);
         }
 
-        private int bracketBalance = 0;
-        private bool MatchBrackets(int offset, char searchBracket, char gotBracket, bool inComment=false)
+        /// <summary>
+        ///  Find current matching brackets.
+        /// </summary>
+        /// <param name="offset">An offset inside brackets to be found.</param>
+        /// <param name="openingBracket"></param>
+        /// <param name="closingBracket"></param>
+        /// <returns></returns>
+        private BracketsMatch FindMatchingBrackets(int offset, char openingBracket, char closingBracket)
         {
-
-            char charAt = '\0';
-            try
+            Stack<int> brackets = new Stack<int>();
+            int firstBracketOffset = 0;
+            int bracketBalance = 0;
+            var i = 0;
+            char currentChar, prevChar, nextChar = '\0';
+            while (i < _textEditor.Text.Length)
             {
-                charAt = _textEditor.Text[offset];
-            }
-            catch
-            {
+                currentChar = _textEditor.Text[i];
+                int skipTo = -1;
 
-            }
-
-            if (charAt == gotBracket)
-            {
-                CommentInfo comment = IsInComment(_textEditor.Text, offset);
-
-                if (inComment == comment.InComment)
+                switch (currentChar)
                 {
-                    bracketBalance++;
+                    case '#':
+                        skipTo = _textEditor.Text.IndexOf('\n', i);
+                        if (skipTo > i)
+                        {
+                            i = skipTo;
+                        }
+                        break;
+                    case '/':
+                        if (i < (_textEditor.Text.Length - 1))
+                        {
+                            nextChar = _textEditor.Text[i+1];
+                            if (nextChar == '/')
+                            {
+                                skipTo = _textEditor.Text.IndexOf('\n', i);
+                                if (skipTo > i)
+                                {
+                                    i = skipTo;
+                                }
+                            }
+                            if (nextChar == '*')
+                            {
+                                skipTo = _textEditor.Text.IndexOf("*/", i);
+                                if (skipTo > i)
+                                {
+                                    i = skipTo;
+                                }
+                            }
+                        }
+                        break;
+                    case '"':
+                        while ((skipTo = _textEditor.Text.IndexOf('"', i+1)) > -1 )
+                        {
+                            prevChar = _textEditor.Text[i - 1];
+                            if (prevChar != '\\')
+                            {
+                                i = skipTo;
+                                break;
+                            }
+                        }
+                        break;
+                    case '\'':
+                        while ((skipTo = _textEditor.Text.IndexOf('\'', i+1)) > -1)
+                        {
+                            prevChar = _textEditor.Text[i - 1];
+                            if (prevChar != '\\')
+                            {
+                                i = skipTo;
+                                break;
+                            }
+                        }
+                        break;
                 }
-            }
-            else if (charAt == searchBracket)
-            {
-                CommentInfo comment = IsInComment(_textEditor.Text, offset);
 
-                if (inComment == comment.InComment)
+                if (skipTo == -1 && currentChar == openingBracket)
                 {
-                    if (bracketBalance == 0)
+                    brackets.Push(i);
+                    if (i >= offset)
                     {
-                        return true;
-                    }
-                    else
-                    {
-                        bracketBalance--;
+                        bracketBalance++;
                     }
                 }
+                else if (skipTo == -1 && currentChar == closingBracket)
+                {
+                    if (brackets.Count > 0)
+                    {
+                        firstBracketOffset = brackets.Pop();
+                        if (i >= offset)
+                        {
+                            if (bracketBalance == 0)
+                            {
+                                return new BracketsMatch(openingBracket, firstBracketOffset, closingBracket, i);
+                            }
+                            else
+                            {
+                                bracketBalance--;
+                            }
+                        }
+                    }
+                }
+
+                i++;
             }
-            return false;
+
+            return null; 
         }
-
         public class CommentInfo
         {
             public Boolean InComment;
@@ -186,5 +252,20 @@ namespace TypeSqf.Edit.Highlighting
             }
         }
 
+        public class BracketsMatch
+        {
+            public char OpeningBracket { get; private set; }
+            public char ClosingBracket { get; private set; }
+            public int OpeningOffset { get; private set; }
+            public int ClosingOffset { get; private set; }
+
+            public BracketsMatch(char openingBracket, int openingOffset, char closingBracket, int closingOffset)
+            {
+                OpeningBracket = openingBracket;
+                OpeningOffset  = openingOffset;
+                ClosingBracket = closingBracket;
+                ClosingOffset  = closingOffset;
+            }
+        }
     }
 }


### PR DESCRIPTION
#9 
Changed the way to do this to loop the document text from the top and skip all:

- strings (both single and double quotes)
- line comments
- block comments
- pre processor commands
